### PR TITLE
make factories create new daos

### DIFF
--- a/contracts/os/DefaultOS.sol
+++ b/contracts/os/DefaultOS.sol
@@ -61,11 +61,9 @@ contract DefaultOS is Ownable {
 
     /// @notice Set organization name and add DAO org ID to DAO tracker
     /// @param organizationName_ Name of org
-    /// @param organizationId_ ID of org
     /// @param factory_ address of DAO factory contract, which keeps track of all DAO OS instances
     constructor(
-        string memory organizationName_,
-        string memory organizationId_,
+        bytes32 memory organizationName_,
         DefaultOSFactory factory_
     ) {
         organizationName = organizationName_;

--- a/contracts/os/DefaultOSFactory.sol
+++ b/contracts/os/DefaultOSFactory.sol
@@ -4,31 +4,25 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "hardhat/console.sol";
+import "./DefaultOS.sol";
 
 /// @title DAO Tracker
 /// @notice Keep track of global state of full list of DAOs and the addresses these DAOs map to
 contract DefaultOSFactory is Ownable { 
     
-  mapping(string => address) public osMap;
+  mapping(bytes32 => address) public osMap;
   address[] private osList;
 
-  event OSCreated(address os, string id);
-
-
-  /// @notice Get the address associated with a DAO's string ID
-  /// @param daoId ID of DAO
-  /// @return address Address associated with the the DAO
-  function getOS(string memory daoId) public view returns (address) {
-    return osMap[daoId];
-  }
+  event OSCreated(address os, bytes32 id);
 
   /// @notice Add a new DAO to full list of DAOs using DefaultOS. 
-  /// @param daoId ID of DAO
-  function setOS(string memory daoId, address os) public {
-    require(osMap[daoId] == address(0), "DefaultOSFactory | setOS(): Alias already taken");
-    osMap[daoId] = os;
-    osList.push(osMap[daoId]);
+  /// @param name_ name of DAO
+  function setOS(bytes32 memory name_) public {
+    require(osMap[name_] == address(0), "DefaultOSFactory | setOS(): Alias already taken");
+    address os = address(new DefaultOS(name_, address(this)));
+    osMap[name_] = os;
+    osList.push(os);
 
-    emit OSCreated(os, daoId);
+    emit OSCreated(os, name);
   }
 }


### PR DESCRIPTION
pair programmed with @fullyallocated. factories should be creating new daos. previously they were only keeping a list of daos. 

also removed the extra daoId parameter to keep it simple. we can add it back once we test it more and think through it more. 

one thing that came to mind is how do we make sure that an invalid string isn't passed and used as a subdomaion. possibly a malicious string could even be passed. 