### PR TITLE
Kevin/os naming and permissioning

### DIFF
--- a/contracts/os/DefaultOS.sol
+++ b/contracts/os/DefaultOS.sol
@@ -4,9 +4,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-
-import "hardhat/console.sol";
-
 import "./DefaultOSFactory.sol";
 
 /// @title Default OS Module Installer
@@ -47,7 +44,7 @@ contract DefaultOSModule is Ownable {
         _OS = os_;
     }
 
-    modifier onlyOS() {      
+    modifier viaGovernance() {      
       require(msg.sender == _OS.owner(), "only the os owner can make this call");
       _;
     }

--- a/contracts/os/DefaultOS.sol
+++ b/contracts/os/DefaultOS.sol
@@ -55,6 +55,7 @@ contract DefaultOSModule is Ownable {
 contract DefaultOS is Ownable {
     bytes32 public organizationName;
     mapping(bytes3 => address) public MODULES;
+    mapping(address => bool) public isModule;    // NOT PROD IMPLEMENTATION——MUST FLIP FALSE UPON UNINSTALL (not implementated yet)
 
     /// @notice Set organization name and add DAO org ID to DAO tracker
     /// @param organizationName_ Name of org
@@ -70,8 +71,10 @@ contract DefaultOS is Ownable {
         external
         onlyOwner
     {
-        bytes3 moduleKeyCode = installer_.moduleKeycode();        
-        MODULES[moduleKeyCode] = installer_.install();
+        bytes3 moduleKeyCode = installer_.moduleKeycode();  
+        address moduleAddr = installer_.install();      
+        MODULES[moduleKeyCode] = moduleAddr;
+        isModule[moduleAddr] = true;
 
         emit ModuleInstalled(address(this), MODULES[moduleKeyCode], moduleKeyCode);
     }

--- a/contracts/os/DefaultOSFactory.sol
+++ b/contracts/os/DefaultOSFactory.sol
@@ -18,7 +18,24 @@ contract DefaultOSFactory is Ownable {
   /// @notice Add a new DAO to full list of DAOs using DefaultOS. 
   /// @param name_ name of DAO
   function setOS(bytes32 name_) public {
+
+    // ensure each name is unique and unreserved
     require(osMap[name_] == address(0), "DefaultOSFactory | setOS(): Alias already taken");
+    
+    // ensure OS names are alphanumeric characters or a hyphen (no spaces)
+    // NOTE: unsure if this should be enforced at the contract level, discuss removal later.
+    for (uint8 i = 0; i < 32; i++) {
+      bytes1 char = name_[i];
+      require(
+        (char >= 0x30 && char <= 0x39) || //9-0
+        (char >= 0x41 && char <= 0x5A) || //A-Z
+        (char >= 0x61 && char <= 0x7A) || //a-z
+        (char == 0x2D || char == 0x00), // hyphen or empty bits
+        "OS Factory: Name must consist of alphanumeric characters or hyphen"
+      );
+    }
+
+    // create the os and transfer ownership to creator, then add to list of OS's created.
     DefaultOS os = new DefaultOS(name_);
     os.transferOwnership(msg.sender);
     osMap[name_] = address(os);

--- a/contracts/os/Epoch/Epoch.sol
+++ b/contracts/os/Epoch/Epoch.sol
@@ -45,17 +45,22 @@ contract def_Epoch is DefaultOSModule {
 
   /// @notice Set amount of tokens that will be minted at the end of each epoch
   /// @param newTokenBonus_ Amount of tokens to be minted each epoch
-  function setTokenBonus(uint256 newTokenBonus_) external onlyOS {
+  function setTokenBonus(uint256 newTokenBonus_) external viaGovernance {
     TOKEN_BONUS = newTokenBonus_;    
   }
 
   /// @notice Once 7 days have passed from the start of the last epoch, start a new epoch and mint new tokens
-  function incrementEpoch() external {        
-    require(block.timestamp >= epochTime + (7 days), "cannot increment epoch before deadline");
+  function incrementEpoch() external {  
+
+    // ***************************************** NOTE *********************************************
+    // we are removing the time lock on incrementing epochs for testing purposes, add back in prod
+    // ********************************************************************************************
+
+    // require(block.timestamp >= epochTime + (7 days), "cannot increment epoch before deadline");
     epochTime = block.timestamp;
     current++;
 
-    _Token.mint(msg.sender, TOKEN_BONUS);
+    // _Token.mint(msg.sender, TOKEN_BONUS);
     emit EpochIncremented(current, epochTime);
   }
 }

--- a/contracts/os/Members/Members.sol
+++ b/contracts/os/Members/Members.sol
@@ -69,7 +69,7 @@ contract def_Members is Staking, DefaultOSModule {
     
     /// @notice Set global limit on endorsements a member can receive from another member
     /// @param newLimit_ Max amount of endorsements a member can receive from another member
-    function setEndorsementLimit(uint256 newLimit_) external onlyOwner {
+    function setEndorsementLimit(uint256 newLimit_) external viaGovernance {
         ENDORSEMENT_LIMIT = newLimit_;
     }
 

--- a/contracts/os/Members/PeerRewards.sol
+++ b/contracts/os/Members/PeerRewards.sol
@@ -112,23 +112,23 @@ contract def_PeerRewards is DefaultOSModule{
     uint8 public MAX_ALLOC_PCTG = 40; // min 3 members
 
     
-    function setParticipationThreshold(uint256 newThreshold_) external onlyOS {
+    function setParticipationThreshold(uint256 newThreshold_) external viaGovernance {
         PARTICIPATION_THRESHOLD = newThreshold_;
     }
 
-    function setRewardsThreshold(uint256 newThreshold_) external onlyOS {
+    function setRewardsThreshold(uint256 newThreshold_) external viaGovernance {
         REWARDS_THRESHOLD = newThreshold_;
     }
 
-    function setContributorEpochRewards(uint256 newEpochRewards_) external onlyOS {
+    function setContributorEpochRewards(uint256 newEpochRewards_) external viaGovernance {
         CONTRIBUTOR_EPOCH_REWARDS = newEpochRewards_;
     }
 
-    function setMinAllocPctg(uint8 newMinAllocPctg_) external onlyOS {
+    function setMinAllocPctg(uint8 newMinAllocPctg_) external viaGovernance {
         MIN_ALLOC_PCTG = newMinAllocPctg_;
     }   
     
-    function setMaxAllocPctg(uint8 newMaxAllocPctg_) external onlyOS {
+    function setMaxAllocPctg(uint8 newMaxAllocPctg_) external viaGovernance {
         MAX_ALLOC_PCTG = newMaxAllocPctg_;
     }
 

--- a/contracts/os/Token/Token.sol
+++ b/contracts/os/Token/Token.sol
@@ -37,7 +37,7 @@ contract def_Token is DefaultOSModule, ERC20("Default Token", "DEF") {
     /// @notice Mint new tokens and assign them to member address
     /// @param member_ Address of member
     /// @param amount_ Number of tokens to transfer
-    function mint(address member_, uint256 amount_) external { // onlyOS("MINTER") -> an OS-whitelist of all the tokens that have the ability to call this function
+    function mint(address member_, uint256 amount_) external viaGovernance {
         _mint(member_, amount_);
     }
 

--- a/contracts/os/Token/Token.sol
+++ b/contracts/os/Token/Token.sol
@@ -33,11 +33,16 @@ contract def_Token is DefaultOSModule, ERC20("Default Token", "DEF") {
 
     constructor(DefaultOS os_) DefaultOSModule(os_) {}
 
+    modifier onlyOS() {      
+      require(_OS.isModule(msg.sender) || msg.sender == _OS.owner(), "only the os modules internally can call this function");
+      _;
+    }
+
 
     /// @notice Mint new tokens and assign them to member address
     /// @param member_ Address of member
     /// @param amount_ Number of tokens to transfer
-    function mint(address member_, uint256 amount_) external viaGovernance {
+    function mint(address member_, uint256 amount_) external onlyOS {
         _mint(member_, amount_);
     }
 

--- a/contracts/os/Treasury/Mining.sol
+++ b/contracts/os/Treasury/Mining.sol
@@ -71,7 +71,7 @@ contract def_Mining is DefaultOSModule {
 
     /// @notice Set weekly token bonus to caller of issueRewards() function.
     /// @param newTokenBonus_ # of tokens to be paid to caller of issueRewards function
-    function setTokenBonus(uint256 newTokenBonus_) external onlyOS {
+    function setTokenBonus(uint256 newTokenBonus_) external viaGovernance {
         TOKEN_BONUS = newTokenBonus_;
     }
 
@@ -101,7 +101,7 @@ contract def_Mining is DefaultOSModule {
     /// @notice Assign the vault contract to be mined. This "activates" the mining program
     /// @param token_ the Address of the token to be mined
     /// @dev The token should have a vault in the treasury before calling this function
-    function assignVault(address token_) external onlyOS {        
+    function assignVault(address token_) external viaGovernance {        
         require (address(_vault) == address(0), "can only assign vault once");        
         _vault = _Treasury.getVault(token_);
     }

--- a/contracts/os/Treasury/Treasury.sol
+++ b/contracts/os/Treasury/Treasury.sol
@@ -60,7 +60,7 @@ contract def_Treasury is DefaultOSModule {
     /// @notice Open a new vault of a specific token for the treasury. (Governance only)
     /// @param token_ Address of token to create a vault for
     /// @param fee_ Percentage fee (0-100) that members will pay to the DAO from each withdrawl
-    function openVault(address token_, uint8 fee_) external onlyOS {
+    function openVault(address token_, uint8 fee_) external viaGovernance {
         // make sure no vault exists for this token
         require(
             address(getVault[token_]) == address(0),
@@ -114,7 +114,7 @@ contract def_Treasury is DefaultOSModule {
     /// @param amountshares_ # of shares to withdrawl in exchange fo
     function withdrawFromVault(Vault vault_, uint256 amountshares_)
         external
-        onlyOS
+        viaGovernance
     {
         // withdraw from the vault to the OS
         vault_.withdraw(address(_OS), amountshares_);
@@ -136,7 +136,7 @@ contract def_Treasury is DefaultOSModule {
     /// @notice Withdraw earned fees from the vault. No fee will be charged on this withdrawl. (Governance only)
     /// @param vault_ Address of vault
     /// @param newFeePctg New percentage fee (0-100) that members will pay to the DAO from each withdrawl
-    function changeFee(Vault vault_, uint8 newFeePctg) external onlyOS {
+    function changeFee(Vault vault_, uint8 newFeePctg) external viaGovernance {
         require(newFeePctg >= 0 && newFeePctg <= 100);
 
         // set the fee to the new fee

--- a/test/DefaultOS.test.js
+++ b/test/DefaultOS.test.js
@@ -5,12 +5,15 @@ describe("DefaultOS.sol", function () {
     before(async function () {
         this.signers = await ethers.getSigners();
         this.dev = this.signers[0];
-        this.factory = await (await ethers.getContractFactory("DefaultOSFactory")).deploy()
-        this.daos = await this.factory.deployed()
+        this.factory = await (await ethers.getContractFactory("DefaultOSFactory")).deploy();
+        this.daos = await this.factory.deployed();
 
-        await this.daos.setOS("0x0000000000000000000000000000000000000000000000000044656661756c74");
-        this.default = await ethers.getContractAt("DefaultOS", await this.daos.osMap("0x0000000000000000000000000000000000000000000000000044656661756c74"));
+        await this.daos.setOS(ethers.utils.formatBytes32String("Valid-Name123"));
+        this.default = await ethers.getContractAt("DefaultOS", await this.daos.osMap(ethers.utils.formatBytes32String("Valid-Name123")));
+    })
 
+    it("enforces naming", async function () {
+        await expect(this.daos.setOS(ethers.utils.formatBytes32String("Invalid Name"))).to.be.revertedWith("OS Factory: Name must consist of alphanumeric characters or hyphen");
     })
 
     // testing is not done here, use a ModuleInstaller stub instead of the Token module
@@ -31,11 +34,11 @@ describe("DefaultOS.sol", function () {
         })
     })
 
-    describe("DefaultOS", async function() {
-      beforeEach(async function () {
-        this.DefaultEpochInstaller = await ethers.getContractFactory("def_EpochInstaller");
-        this.epochModule = await this.DefaultEpochInstaller.deploy();
-        await this.epochModule.deployed();
-      })
-    })
+    // describe("DefaultOS", async function() {
+    //   beforeEach(async function () {
+    //     this.DefaultEpochInstaller = await ethers.getContractFactory("def_EpochInstaller");
+    //     this.epochModule = await this.DefaultEpochInstaller.deploy();
+    //     await this.epochModule.deployed();
+    //   })
+    // })
 })

--- a/test/modules/Epoch.test.js
+++ b/test/modules/Epoch.test.js
@@ -49,7 +49,9 @@ describe("Epoch.sol", function () {
       await incrementWeek(sixDays)
 
       // https://github.com/EthWorks/Waffle/issues/95
-      await expect(this.epoch.incrementEpoch()).to.be.revertedWith("cannot increment epoch before deadline");
+
+      // **** CODE BELOW WAS COMMENTED FOR TESTING PHASE *****
+      // await expect(this.epoch.incrementEpoch()).to.be.revertedWith("cannot increment epoch before deadline");
     })
 
     it("sets token bonus", async function() {      
@@ -70,10 +72,13 @@ describe("Epoch.sol", function () {
       await incrementWeek()
   
       await this.epoch.incrementEpoch()
-  
-      expect(await this.token.balanceOf(this.dev.address)).to.equal(
-        await this.epoch.TOKEN_BONUS()
-      )
+      
+
+      // remove token bonus upon manual incrementing—to address later
+
+      // expect(await this.token.balanceOf(this.dev.address)).to.equal(
+      //   await this.epoch.TOKEN_BONUS()
+      // )
     })  
   })
 })


### PR DESCRIPTION
Few changes:

1) Add OS naming rules (no spaces, alphanumeric + hyphens only)
 - we should discuss keeping this in the release version of the OS. For now we'll add it to make front-end dev easier as per @tsully's request but I don't know if it's a long term feature. Let's talk about it.
 
2) Change epoch to be manually incremented without the timeout (7 days) or the token bonus (mint).
- change the tests to reflect the contract changes
- this is just for testing purposes so when we deploy live we don't have to wait 7 days to make sure everything is working.
- also strongly considering changing epoch to be auto-incremented as a function of blockheight. --> set by configuration?

3) Change "onlyOS" to "viaGovernance" — variables that will eventually be set by an external address. This can start as the dev address for easy control and be upgraded to multisig/direct voting as we roll out governance upgrades.

4) Add "onlyOS" to Token minting—allowing contracts within the OS to mint, and the dev wallet (just so tests don't break for now when we mint tokens, although we should remove this in the prod environment so that token supply is purely a function of configuration + policy via installed modules.

